### PR TITLE
Update tags.js to close [400]

### DIFF
--- a/kubejs/server_scripts/base/tags.js
+++ b/kubejs/server_scripts/base/tags.js
@@ -73,3 +73,9 @@ addToTag('forge:canvasables', [
     'ae2:silicon',
     'dried_kelp'
 ])
+
+addFluidToTag(`create:bottomless/allow`, [
+    'minecraft:milk',
+    'create:chocolate',
+    'create:honey'
+])

--- a/kubejs/server_scripts/base/tags.js
+++ b/kubejs/server_scripts/base/tags.js
@@ -74,7 +74,7 @@ addToTag('forge:canvasables', [
     'dried_kelp'
 ])
 
-addFluidToTag(`create:bottomless/allow`, [
+addFluidToTag('create:bottomless/allow', [
     'minecraft:milk',
     'create:chocolate',
     'create:honey'


### PR DESCRIPTION
Updated tags.js to add milk, chocolate, and honey to the create bottomless fluids tag. Currently, the pack is configured to consider any source >= 4000 source blocks as infinite.