### PR TITLE
Feat: removed deepslate

### DIFF
--- a/kubejs/data/minecraft/worldgen/noise_settings/overworld.json
+++ b/kubejs/data/minecraft/worldgen/noise_settings/overworld.json
@@ -2522,7 +2522,7 @@
           "false_at_and_above": {
             "absolute": 8
           },
-          "random_name": "minecraft:deepslate",
+          "random_name": "minecraft:blue_terracotta",
           "true_at_and_below": {
             "absolute": 0
           }
@@ -2530,7 +2530,7 @@
         "then_run": {
           "type": "minecraft:block",
           "result_state": {
-            "Name": "minecraft:deepslate",
+            "Name": "minecraft:blue_terracotta",
             "Properties": {
               "axis": "y"
             }


### PR DESCRIPTION
This commit removes minecraft:deepslate from generating (issue #231) and replaces it with minecraft:blue_terracotta

This commit does not affect seeds as it is a 1:1 replacement of the block. So any seeds will generate the exact same landscape.