### PR TITLE
Adds deployer recipe for name tag

### DIFF
--- a/kubejs/server_scripts/base/featrues/items.js
+++ b/kubejs/server_scripts/base/featrues/items.js
@@ -1,0 +1,1 @@
+addDeploying('minecraft:name_tag', 'minecraft:light_weighted_pressure_plate', 'minecraft:chain')


### PR DESCRIPTION
This is from https://discord.com/channels/890222432605057044/1185295028831125574

Adds a recipe for deployer block to create name tags from light weighted pressure plate (yellow pressure plate) and chains

The light weighted pressure plate item still needs to be renamed to Yellow Pressure Plate.