### PR TITLE
Updating Prepare to Dye Plus to 1.3.38

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "dabd5868f77835fb30696555b92dc274a76cab50b084f0c33748c4732508bf1e"
+hash = "a0418fa499e4f94ffe1cd318551325a122271a3c8be198b584a69e53620edd45"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.0+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.27+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "ff012f3fd3c25265e78da3f91e5777ac"
+hash = "9cba1583a59bffb6bf8471059286fd7ee940db01"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5014880
+file-id = 5018008
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "be4f20672590e9f96a5612e7b6dca0aa1950e5bb806cb9899194d4d149bba563"
+hash = "a7c3b939b79e1abf1c4cc437955de14f1e331772c7e7e77c7eb5bf300862dab9"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7527,7 +7527,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "91afd14363b08e2c1982d1720f8f24b84bbd24cb8d96b8937e859640cd6020d3"
+hash = "433f6e9d51616d11388fb919f968b4b63d25d6a16c38464078b81a8c3860f0c4"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.0+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.27+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/z8VgyUHi/ptdyeplus-1.3.0%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/W18XFoS6/ptdyeplus-1.3.27%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "c1db0cb2abb5fec2ddd4bf87ccb8e95768eda86a"
+hash = "386d99b3a465f4436953d220f36599e9fce43115"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "z8VgyUHi"
+version = "W18XFoS6"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "76e50b4097c1eb1bbe4008f30d5941c76bc24e89b7c850140f27ac64ecbf61f5"
+hash = "8b984113f0fc8183a6030634129956e51cf7e039e65da09630935903cd32ad53"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
# Updating Prepare to Dye Plus to 1.3.38. 

 ### [1.3.38](https://github.com/jasperalani/ptdye-plus/compare/1.3.37...1.3.38) (2024-01-08)