### PR TITLE
Updating Prepare to Dye Plus to 1.3.39

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -7531,7 +7531,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "433f6e9d51616d11388fb919f968b4b63d25d6a16c38464078b81a8c3860f0c4"
+hash = "f2de48f3620d118fab2dbb868d188e30bc6ab38dd74f1b565222c469a5d88454"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -3,11 +3,11 @@ filename = "ptdyeplus-1.3.27+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/W18XFoS6/ptdyeplus-1.3.27%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/ah5kaD9t/ptdyeplus-1.3.27%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "386d99b3a465f4436953d220f36599e9fce43115"
+hash = "713b1ee48c2e3c59a1636f99e74bb203c3dbdc2d"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "W18XFoS6"
+version = "ah5kaD9t"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "59675857299c48969cce1251ca4450d1b9896b198bf87d18cd32e4af0a648346"
+hash = "092fa2973471fc1cd03fcdea4cbdc62acb51e59e809215ce96929982ee524638"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
# Updating Prepare to Dye Plus to 1.3.39. 

 ### [1.3.39](https://github.com/jasperalani/ptdye-plus/compare/1.3.38...1.3.39) (2024-01-08)