### PR TITLE
Updating Prepare to Dye Plus to 1.3.40

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "a0418fa499e4f94ffe1cd318551325a122271a3c8be198b584a69e53620edd45"
+hash = "35d5699e3a2bacbaf87ca8d2cd6ce7c1ac039e244865a404c3051afcf5c763d2"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.27+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.0+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "9cba1583a59bffb6bf8471059286fd7ee940db01"
+hash = "c1db0cb2abb5fec2ddd4bf87ccb8e95768eda86a"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5018008
+file-id = 5014880
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "a7c3b939b79e1abf1c4cc437955de14f1e331772c7e7e77c7eb5bf300862dab9"
+hash = "23b6fc4772e5d2b59c5d5fdb9b2dec68a51ef309a4ed9ba8b900b3ab1cc26ecc"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7531,7 +7531,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "433f6e9d51616d11388fb919f968b4b63d25d6a16c38464078b81a8c3860f0c4"
+hash = "f8d947dc5cb9d2b00f5bdebf4166be3aba6c3f21b207e84bc28eca4f6c1825e8"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.27+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.1+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/W18XFoS6/ptdyeplus-1.3.27%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/mAFuo1Nm/ptdyeplus-1.3.1%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "386d99b3a465f4436953d220f36599e9fce43115"
+hash = "3f1c11dfcff470c3bb7875110ad7d71b8aa10d4a"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "W18XFoS6"
+version = "mAFuo1Nm"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "59675857299c48969cce1251ca4450d1b9896b198bf87d18cd32e4af0a648346"
+hash = "3e1408cf06729927bc1ffb1ff0a9c682326618370ce8bd0137f8d8bfae20a9df"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
# Updating Prepare to Dye Plus to 1.3.40. 

 ### [1.3.40](https://github.com/jasperalani/ptdye-plus/compare/1.3.39...1.3.40) (2024-01-08)