### PR TITLE
Updating Prepare to Dye Plus to 1.3.11

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "a0418fa499e4f94ffe1cd318551325a122271a3c8be198b584a69e53620edd45"
+hash = "f9ae1dcca018c0497c2a08c88dd80038a66b97b192f6dc44ce50a0043dbcb9ff"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.27+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.3+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "9cba1583a59bffb6bf8471059286fd7ee940db01"
+hash = "06fb1db62a8dc48905f1881988a0ff392ff40c6b"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5018008
+file-id = 5019070
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "a7c3b939b79e1abf1c4cc437955de14f1e331772c7e7e77c7eb5bf300862dab9"
+hash = "8698191505cc2376ceea172ca07c161a5dbf222fd9adcd731165cd438c0a62c1"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7531,7 +7531,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "433f6e9d51616d11388fb919f968b4b63d25d6a16c38464078b81a8c3860f0c4"
+hash = "67e9bd28a643faa4aaba5e23874c53770769e358e1a8e4ebebbe59a5bd07d97c"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.27+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.3+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/W18XFoS6/ptdyeplus-1.3.27%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/P2WhkUCD/ptdyeplus-1.3.3%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "386d99b3a465f4436953d220f36599e9fce43115"
+hash = "41fbb70d1f2898f3d6d982584d97bddf691f4742"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "W18XFoS6"
+version = "P2WhkUCD"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "59675857299c48969cce1251ca4450d1b9896b198bf87d18cd32e4af0a648346"
+hash = "8c2bcb1c27ddca393866fd3ced2743c3ba27e40991c0f07f14bf24dc7b5d2062"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.11](https://github.com/jasperalani/ptdye-plus/compare/1.3.10...1.3.11) (2024-01-09)


### Developer experience improvements and changes

* adds auto commit ([8d1b1bf](https://github.com/jasperalani/ptdye-plus/commit/8d1b1bfd83ae838ab526182aff49a315b1041273))