### PR TITLE
Updating Prepare to Dye Plus to 1.3.8

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -7571,7 +7571,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "3275682af759449160e0ce0c3b68682112414f4aafe014efffb5c356c4c387e0"
+hash = "0d2f08235c0c5fc97a964b7bace6bcd31972f468b48de166bb25ac44de244387"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/uyzG4Y6H/ptdyeplus-1.3.7%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/3bIk5BXQ/ptdyeplus-1.3.11%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "16448e04649845d7c3634de0e4af8434480abc09"
+hash = "3b438105c29b71364d71597c8a1f7a9682890d6d"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "uyzG4Y6H"
+version = "3bIk5BXQ"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3db3b79b0b5cd6aaa32886a2423f6db52b79495c10cb850c8ae2c29106179436"
+hash = "aa70c9677afcd82074231fc551a6c6c1c2a97fc20775e33922e75f7a93ee33cf"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.8](https://github.com/jasperalani/ptdye-plus/compare/1.3.7...1.3.8) (2024-01-14)