### PR TITLE
Updating Prepare to Dye Plus to 1.3.9

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "612ec1fb99ce6d17735a2e4d51fdc76e91cf3a26d49ded6c3f65c7f1cc005ba4"
+hash = "bbc6d07e995aa9b1dae83a9cbfdaf5c8a047c3d45d817009ecc0f0255f28664c"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "51b592688e178b59b1838ac8dbaa8248"
+hash = "0b4d55806eef844cc4fb7428ef5049178d78af58"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5019109
+file-id = 5032835
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "69663e5a198ce5f5016206c92ef4b6877bcce3c83f457df8fa5c1a2ddc509173"
+hash = "a70a00f94ccd51ebcfc6f6deec0bf32a238d25164a33ee7d517dd76f2a5b8e58"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7611,7 +7611,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "3275682af759449160e0ce0c3b68682112414f4aafe014efffb5c356c4c387e0"
+hash = "1b5232354b9419bc7afe4033293fc33932f7877fe2f79028101f7ca57e212f0f"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.12+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/uyzG4Y6H/ptdyeplus-1.3.7%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/wA7m8O0F/ptdyeplus-1.3.12%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "16448e04649845d7c3634de0e4af8434480abc09"
+hash = "bab931aadb7664b8a20abb9fea9d2163ae0b07c4"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "uyzG4Y6H"
+version = "wA7m8O0F"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "6479ffa5051a5bb9279400897d589e423df4f542c55339cb0dd357162298fb18"
+hash = "358250710c28d800fce4f7d3b62193d6e65a9fdf2615e54ba36674be411105dd"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.9](https://github.com/jasperalani/ptdye-plus/compare/1.3.8...1.3.9) (2024-01-15)


### Developer experience improvements and changes

* uses tag from previous task to update version files ([3e8e476](https://github.com/jasperalani/ptdye-plus/commit/3e8e476059d9065cafb84371514cc5554c473277))