### PR TITLE
Updating Prepare to Dye Plus to 1.3.10

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "612ec1fb99ce6d17735a2e4d51fdc76e91cf3a26d49ded6c3f65c7f1cc005ba4"
+hash = "bbc6d07e995aa9b1dae83a9cbfdaf5c8a047c3d45d817009ecc0f0255f28664c"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.10+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "0b4d55806eef844cc4fb7428ef5049178d78af58"
+hash = "0a17ed28138397958aa703fa2f63a2e5"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5032835
+file-id = 5033134
 project-id = 952113

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "51b592688e178b59b1838ac8dbaa8248"
+hash = "0b4d55806eef844cc4fb7428ef5049178d78af58"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5019109
+file-id = 5032835
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "69663e5a198ce5f5016206c92ef4b6877bcce3c83f457df8fa5c1a2ddc509173"
+hash = "a70a00f94ccd51ebcfc6f6deec0bf32a238d25164a33ee7d517dd76f2a5b8e58"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7611,7 +7611,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "3275682af759449160e0ce0c3b68682112414f4aafe014efffb5c356c4c387e0"
+hash = "963e40d8479f097ef550979bfd80fa01f2b13c71644fc9e8362c928ec56e230d"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.13+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/uyzG4Y6H/ptdyeplus-1.3.7%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/oYA8nC6s/ptdyeplus-1.3.13%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "16448e04649845d7c3634de0e4af8434480abc09"
+hash = "7aa3f31cc11606da0b6358bae5b017b1c76f9b90"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "uyzG4Y6H"
+version = "oYA8nC6s"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "6479ffa5051a5bb9279400897d589e423df4f542c55339cb0dd357162298fb18"
+hash = "0811b6eebd96f4f87ffd7a6eaf5117f45f4f493936fe1c1ef035612c2a91ea78"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.10](https://github.com/jasperalani/ptdye-plus/compare/1.3.9...1.3.10) (2024-01-15)